### PR TITLE
Set sentinel channels to be optional

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,7 +119,7 @@ export type YBlockSentinel = {
   'notify-config': {
     timeout?: number;
     message?: string;
-    channels: YNotification[];
+    channels?: YNotification[];
   };
   conditions?: {
     event: { signature: string; expression?: string }[];
@@ -141,7 +141,7 @@ export type YFortaSentinel = {
   'notify-config': {
     timeout?: number;
     message?: string;
-    channels: YNotification[];
+    channels?: YNotification[];
   };
   conditions?: {
     'min-scanner-count': number;


### PR DESCRIPTION
Via the GUI it is possible to have Sentinels with only an Autotask trigger. It even lets me save the sentinel without any notification selected. So an empty notification channel is a valid configuration. 

Users should be allowed to stage sentinels without connecting them to a notification channel.