### PR TITLE
Fix opsgenie and pagerduty support

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -125,11 +125,45 @@ export type YDatadogConfig = {
   'metric-prefix': string;
 };
 
+export type YOpsgenieConfig = {
+  apiKey: string;
+  instanceLocation: string;
+  alias?: string;
+  responders?: object[];
+  visibleTo?: object[];
+  actions?: object[];
+  tags?: string[];
+  details?: object;
+  entity?: string;
+  priority?: string;
+  note?: string;
+};
+
+export type YPagerdutyConfig = {
+  token: string;
+  eventType: string;
+  routingKey: string;
+  eventAction?: string;
+  dedupKey?: string;
+  severity?: string;
+  component?: string;
+  group?: string;
+  class?: string;
+  customDetails?: object;
+};
+
 export type YNotification = SaveNotificationRequest & {
   type: NotificationType;
   name: string;
   paused: boolean;
-  config: YSlackConfig | YTelegramConfig | YDatadogConfig | YDiscordConfig | YEmailConfig;
+  config:
+    | YSlackConfig
+    | YTelegramConfig
+    | YDatadogConfig
+    | YDiscordConfig
+    | YEmailConfig
+    | YOpsgenieConfig
+    | YPagerdutyConfig;
 };
 
 export type YCategory = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,8 @@ import {
   MonitorFilterTrigger,
 } from '@openzeppelin/defender-autotask-client/lib/models/autotask';
 import { BlockExplorerApiKeyResponse, DeploymentConfigResponse } from '@openzeppelin/platform-deploy-client';
+import { OpsgenieConfig } from '@openzeppelin/defender-sentinel-client/lib/models/opsgenie';
+import { PagerDutyConfig } from '@openzeppelin/defender-sentinel-client/lib/models/pager-duty';
 
 export type DefenderAPIError = DefenderApiResponseError;
 export type DefenderRelayerApiKey = RelayerApiKey;
@@ -125,32 +127,8 @@ export type YDatadogConfig = {
   'metric-prefix': string;
 };
 
-export type YOpsgenieConfig = {
-  apiKey: string;
-  instanceLocation: string;
-  alias?: string;
-  responders?: object[];
-  visibleTo?: object[];
-  actions?: object[];
-  tags?: string[];
-  details?: object;
-  entity?: string;
-  priority?: string;
-  note?: string;
-};
-
-export type YPagerdutyConfig = {
-  token: string;
-  eventType: string;
-  routingKey: string;
-  eventAction?: string;
-  dedupKey?: string;
-  severity?: string;
-  component?: string;
-  group?: string;
-  class?: string;
-  customDetails?: object;
-};
+export type YOpsgenieConfig = OpsgenieConfig;
+export type YPagerdutyConfig = PagerDutyConfig;
 
 export type YNotification = SaveNotificationRequest & {
   type: NotificationType;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,8 @@ import {
   YEmailConfig,
   YDiscordConfig,
   YDatadogConfig,
+  YOpsgenieConfig,
+  YPagerdutyConfig,
   DefenderAutotask,
   DefenderNotification,
   DefenderBlockSentinel,
@@ -190,6 +192,14 @@ export const constructNotification = (notification: YNotification, stackResource
         botToken: currentConfig['bot-token'],
         chatId: currentConfig['chat-id'],
       };
+      return { ...commonNotification, config };
+    case 'opsgenie':
+      currentConfig = notification.config as YOpsgenieConfig;
+      config = currentConfig;
+      return { ...commonNotification, config };
+    case 'pagerduty':
+      currentConfig = notification.config as YPagerdutyConfig;
+      config = currentConfig;
       return { ...commonNotification, config };
     default:
       throw new Error(`Incompatible notification type ${notification.type}`);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -197,7 +197,7 @@ export const constructNotification = (notification: YNotification, stackResource
       currentConfig = notification.config as YOpsgenieConfig;
       config = currentConfig;
       return { ...commonNotification, config };
-    case 'pagerduty':
+    case 'pager-duty':
       currentConfig = notification.config as YPagerdutyConfig;
       config = currentConfig;
       return { ...commonNotification, config };


### PR DESCRIPTION
## Changes
- Add config objects for opsgenie and pagerduty. I imported the ones from the Defender sentinel client to avoid excesive repetition since the objects were large.
- Add both channels to the switch statement