### PR TITLE
Validate permissions during SSOT check

### DIFF
--- a/examples/defender-test-project/package.json
+++ b/examples/defender-test-project/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@openzeppelin/defender-serverless": "^1.2.0",
+    "@openzeppelin/defender-serverless": "^1.2.1",
     "serverless": "^3.20.0"
   }
 }

--- a/examples/defender-test-project/yarn.lock
+++ b/examples/defender-test-project/yarn.lock
@@ -29,9 +29,9 @@
     tslib "^1.11.1"
 
 "@aws-sdk/types@^3.1.0":
-  version "3.347.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.347.0.tgz#4affe91de36ef227f6375d64a6efda8d4ececd5d"
-  integrity sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==
+  version "3.357.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.357.0.tgz#8491da71a4291cc2661c26a75089e86532b6a3b5"
+  integrity sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==
   dependencies:
     tslib "^2.5.0"
 
@@ -479,6 +479,20 @@
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
+"@openzeppelin/defender-serverless@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-serverless/-/defender-serverless-1.2.1.tgz#1c5eedd8d0631336854910889fb6997133757e14"
+  integrity sha512-fnXoU+nTVK1zsZ1ZVX1Y3oTG63UZ6bBoOGNamgYTRF+z2ZemxgFPVg4nrvLLWRfwRPZyG87lLo0WTkjFJqFqdg==
+  dependencies:
+    "@openzeppelin/defender-admin-client" "^1.46.0"
+    "@openzeppelin/defender-autotask-client" "^1.46.0"
+    "@openzeppelin/defender-relay-client" "^1.46.0"
+    "@openzeppelin/defender-sentinel-client" "^1.46.0"
+    "@openzeppelin/platform-deploy-client" "^0.8.0"
+    keccak256 "^1.0.6"
+    lodash "^4.17.21"
+    prompt "^1.3.0"
+
 "@openzeppelin/platform-deploy-client@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/platform-deploy-client/-/platform-deploy-client-0.8.0.tgz#af6596275a19c283d6145f0128cc1247d18223c1"
@@ -674,9 +688,9 @@ ajv@^8.0.0, ajv@^8.12.0:
     uri-js "^4.2.2"
 
 amazon-cognito-identity-js@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.2.0.tgz#99e96666944429cb8f67b62e4cf7ad77fbe71ad0"
-  integrity sha512-9Fxrp9+MtLdsJvqOwSaE3ll+pneICeuE3pwj2yDkiyGNWuHx97b8bVLR2bOgfDmDJnY0Hq8QoeXtwdM4aaXJjg==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.1.tgz#d9a4c1a92f4b059330df8ea075f65106d2605409"
+  integrity sha512-PxBdufgS8uZShrcIFAsRjmqNXsh/4fXOWUGQOUhKLHWWK1pcp/y+VeFF48avXIWefM8XwsT3JlN6m9J2eHt4LA==
   dependencies:
     "@aws-crypto/sha256-js" "1.2.2"
     buffer "4.9.2"
@@ -1297,20 +1311,6 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
-
-defender-serverless@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/defender-serverless/-/defender-serverless-1.1.0.tgz#f121f6cb469923f91ad47ba4cc019c514118d145"
-  integrity sha512-YQzBrUp+2/utdmfK93pnwH/2PsYdrxMTDJvcyfxLT9ufrpmcA2Had9sPA9f7u31ZAFtNrUKeuz0VQklful4cOw==
-  dependencies:
-    "@openzeppelin/defender-admin-client" "^1.46.0"
-    "@openzeppelin/defender-autotask-client" "^1.46.0"
-    "@openzeppelin/defender-relay-client" "^1.46.0"
-    "@openzeppelin/defender-sentinel-client" "^1.46.0"
-    "@openzeppelin/platform-deploy-client" "^0.8.0"
-    keccak256 "^1.0.6"
-    lodash "^4.17.21"
-    prompt "^1.3.0"
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
@@ -2528,9 +2528,9 @@ node-dir@^0.1.17:
     minimatch "^3.0.2"
 
 node-fetch@^2.6.0, node-fetch@^2.6.1:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
-  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
+  integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -3325,9 +3325,9 @@ tslib@^2.1.0:
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@^2.3.1, tslib@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
-  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 type-fest@^0.21.3:
   version "0.21.3"


### PR DESCRIPTION
When `ssot` is enabled, it breaks the deployment due to missing API key permissions for deploymentConfig. This is because there are additional featureFlags that need to be enabled specifically to manage deployments. We already validate the API key for additional permissions when deploying. However, we also need to add similar, though non-blocking, validation in the function that occurs specifically when the `ssot` flag is enabled.